### PR TITLE
Adding fix for opIds that do not start with the correct verb 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5506,15 +5506,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "no-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-      "requires": {
-        "lower-case": "^2.0.1",
-        "tslib": "^1.10.0"
-      }
-    },
     "nise": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
@@ -5526,6 +5517,15 @@
         "just-extend": "^4.0.2",
         "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "no-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "requires": {
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
       }
     },
     "node-emoji": {

--- a/src/cli-validator/runValidator.js
+++ b/src/cli-validator/runValidator.js
@@ -251,7 +251,6 @@ const processInput = async function(program) {
     if (errorsOnly) {
       results.warning = false;
     }
-
     if (doFixProblems || doFixProblemsNewFile) {
       fixProblems(
         results,

--- a/src/cli-validator/utils/fixProblems.js
+++ b/src/cli-validator/utils/fixProblems.js
@@ -174,6 +174,36 @@ module.exports = function print(
             unmarkIfMarkedForMoving(path, parent);
           }
         } else if (
+          message.includes('operationIds should follow consistent naming convention')
+        ) {
+          const validVerbs = ['get', 'create', 'add', 'list', 'update', 'replace', 'delete'];
+
+          const messageArray = message.split(' ');
+          const verb = messageArray[messageArray.length - 1];
+          if (validVerbs.includes(verb)) {
+            const previousOpIdArray = snakeCase.snakeCase(parent[path[path.length - 1]]).toLowerCase().split('_');
+            let updatedOpIdArray;
+            // handling case where the first word in the opId is a verb but should be a different verb.
+            // for example, 'update' used when it should have been 'replace'
+            if (validVerbs.includes(previousOpIdArray[0])) {
+              updatedOpIdArray = previousOpIdArray;
+              updatedOpIdArray[0] = verb;
+            } else {
+              updatedOpIdArray = [verb, ...previousOpIdArray];
+            }
+            const opIdCase =
+              configObject['shared']['operations'][
+                'operation_id_case_convention'
+              ][1];
+            if (opIdCase === 'lower_snake_case') {
+              parent[path[path.length - 1]] = updatedOpIdArray.join('_').toLowerCase();
+            } else if (opIdCase === 'upper_snake_case') {
+              parent[path[path.length - 1]] = updatedOpIdArray.join('_').toUpperCase();
+            } else if (opIdCase === 'lower_camel_case') {
+              parent[path[path.length - 1]] = camelCase(updatedOpIdArray.join('_'));
+            }
+          }
+        } else if (
           message.includes('operationIds must follow case convention')
         ) {
           const opIdCase =


### PR DESCRIPTION
Changes:
- added conditional block for the expected message
- get the verb from the end of the error message and verify it's a valid verb (in case error message changes)
- get the previous opId value as an array, and if the first word in that array is a verb, incorrect verb must be used, so we replace the verb
- otherwise, we prepend verb to the original name
- use case convention config option to format the new name correctly